### PR TITLE
Support Philips 9290022169 as 4080130P6

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -706,7 +706,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LTA001'],
+        zigbeeModel: ['LTA001', '4080130P6'],
         model: '9290022169',
         vendor: 'Philips',
         description: 'Hue white ambiance E27 with Bluetooth',


### PR DESCRIPTION
Philips Hue bulb light model 9290022169 is also discovered as 4080130P6